### PR TITLE
Move DISABLE_DEBUG_FLOAT to common config

### DIFF
--- a/opus_ng/opus/BUILD.gn
+++ b/opus_ng/opus/BUILD.gn
@@ -34,6 +34,7 @@ config("opus_private_config") {
     "OPUS_BUILD",
     "OPUS_EXPORT=",
     "ENABLE_HARDENING",
+    "DISABLE_DEBUG_FLOAT",
 
     # Prefer alloca() over variable length arrays which are often inefficient;
     # the opus code will automatically handle this correctly per-platform.
@@ -89,7 +90,6 @@ config("opus_private_config") {
       "OPUS_HAVE_RTCD",
       "CPU_INFO_BY_ASM",
       "FLOAT_APPROX",
-      "DISABLE_DEBUG_FLOAT",
 
       # Chrome always targets SSE2+.
       "OPUS_X86_MAY_HAVE_SSE",


### PR DESCRIPTION
Makes the binary size for all builds smaller.